### PR TITLE
Add advert caching and meta enrichment

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,6 +200,26 @@
 
         // --- CORE FUNCTIONS ---
 
+        const advertCache = new Map();
+
+        async function getAdvert(id) {
+            if (!id) return null;
+            if (advertCache.has(id)) return advertCache.get(id);
+            const lsKey = `advert_${id}`;
+            const cached = localStorage.getItem(lsKey);
+            if (cached) {
+                const advert = JSON.parse(cached);
+                advertCache.set(id, advert);
+                return advert;
+            }
+            const response = await fetch(`https://www.olx.bg/api/partner/adverts/${id}`);
+            if (!response.ok) throw new Error('Advert fetch failed');
+            const advert = await response.json();
+            advertCache.set(id, advert);
+            localStorage.setItem(lsKey, JSON.stringify(advert));
+            return advert;
+        }
+
         async function fetchThreads() {
             elements.loader.classList.remove('hidden');
             elements.threadsList.innerHTML = '';
@@ -215,14 +235,26 @@
                     return;
                 }
 
-                threads.forEach(thread => {
+                for (const thread of threads) {
+                    const meta = getThreadMeta(thread.id);
+                    if (thread.advert_id) {
+                        try {
+                            const advert = await getAdvert(thread.advert_id);
+                            meta.advertTitle = advert.title || meta.advertTitle;
+                            meta.advertCreatedAt = advert.created_at || meta.advertCreatedAt;
+                            meta.contactName = advert.contact?.name || meta.contactName;
+                            saveThreadMeta(thread.id, meta);
+                        } catch (err) {
+                            // ignore fetch errors
+                        }
+                    }
+
                     const threadElement = document.createElement('div');
                     threadElement.className = 'thread-item';
                     threadElement.dataset.threadId = thread.id;
 
-                    const meta = getThreadMeta(thread.id);
                     const isRead = meta.isRead ?? (thread.unread_count === 0);
-                    const shortName = meta.shortName || '';
+                    const shortValue = meta.shortName || meta.advertTitle || '';
                     const orderStatus = meta.orderStatus || 'pending';
                     const shipping = meta.shipping || '';
                     const lastDate = formatDate(thread.last_message_date);
@@ -234,7 +266,7 @@
                     threadElement.innerHTML = `
                         <input type="checkbox" class="thread-checkbox" data-id="${thread.id}">
                         <div class="thread-item-info">
-                            <p><span class="user-name">${interlocutorName}</span><input class="short-ad-name" value="${shortName}" placeholder="${advertTitle || 'Кратко име'}"></p>
+                            <p><span class="user-name">${interlocutorName}</span><input class="short-ad-name" value="${shortValue}" placeholder="${advertTitle || 'Кратко име'}"></p>
                             <small class="advert-title">${advertTitle}</small>
                             <small>Последно: ${lastDate}</small>
                         </div>
@@ -310,7 +342,7 @@
                     refreshThreadDetails(thread.id, threadElement, meta, shortInput);
 
                     elements.threadsList.appendChild(threadElement);
-                });
+                }
             } catch (error) {
                 elements.threadsList.innerHTML = `<p style="color: red; padding: 15px;">${error.message}</p>`;
             } finally {


### PR DESCRIPTION
## Summary
- добавена getAdvert() с Map/localStorage кеш за обяви
- fetchThreads извиква getAdvert при advert_id и попълва meta
- използване на кеширани заглавия и имена при създаване на thread item

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9104791e48326b39d2f38921c97ba