### PR TITLE
Handle token refresh and unify authorization

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,35 @@
+(function(){
+  const TOKEN_KEY = 'auth_token';
+
+  function getToken() {
+    return localStorage.getItem(TOKEN_KEY);
+  }
+
+  function setToken(token) {
+    localStorage.setItem(TOKEN_KEY, token);
+  }
+
+  async function refreshToken() {
+    const response = await fetch(`${API_BASE_URL}/api/refresh-token`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${getToken()}`
+      }
+    });
+    if (!response.ok) throw new Error('Refresh token failed');
+    const data = await response.json();
+    setToken(data.token);
+    return data.token;
+  }
+
+  async function authorizedFetch(url, options = {}) {
+    const headers = new Headers(options.headers || {});
+    const token = getToken();
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+    options.headers = headers;
+    return fetch(url, options);
+  }
+
+  window.refreshToken = refreshToken;
+  window.authorizedFetch = authorizedFetch;
+})();

--- a/index.html
+++ b/index.html
@@ -139,6 +139,7 @@
         </div>
     </div>
 
+    <script src="auth.js"></script>
     <script>
         // --- CONFIGURATION ---
         const API_BASE_URL = 'https://olx.radilov-k.workers.dev';
@@ -212,7 +213,11 @@
                 advertCache.set(id, advert);
                 return advert;
             }
-            const response = await fetch(`https://www.olx.bg/api/partner/adverts/${id}`);
+            let response = await authorizedFetch(`https://www.olx.bg/api/partner/adverts/${id}`);
+            if (response.status === 401) {
+                await refreshToken();
+                response = await authorizedFetch(`https://www.olx.bg/api/partner/adverts/${id}`);
+            }
             if (!response.ok) throw new Error('Advert fetch failed');
             const advert = await response.json();
             advertCache.set(id, advert);
@@ -224,7 +229,11 @@
             elements.loader.classList.remove('hidden');
             elements.threadsList.innerHTML = '';
             try {
-                const response = await fetch(`${API_BASE_URL}/api/threads`);
+                let response = await authorizedFetch(`${API_BASE_URL}/api/threads`);
+                if (response.status === 401) {
+                    await refreshToken();
+                    response = await authorizedFetch(`${API_BASE_URL}/api/threads`);
+                }
                 if (!response.ok) {
                     const errorData = await response.json();
                     throw new Error(`${errorData.error} <a href="${AUTH_URL}">Оторизирайте се отново</a>.`);
@@ -356,7 +365,7 @@
             const btn = threadElement.querySelector('.details-button');
             if (btn) btn.disabled = true;
             try {
-                const response = await fetch(`${API_BASE_URL}/api/threads/${id}/details`);
+                const response = await authorizedFetch(`${API_BASE_URL}/api/threads/${id}/details`);
                 if (!response.ok) throw new Error('fetch failed');
                 const data = await response.json();
                 meta.advertTitle = data.advertTitle || '';
@@ -383,7 +392,7 @@
             elements.analyzerInput.value = '';
 
             try {
-                const response = await fetch(`${API_BASE_URL}/api/threads/${threadId}/messages`);
+                const response = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/messages`);
                 if (!response.ok) throw new Error('Неуспешно зареждане на съобщенията.');
                 
                 const messages = await response.json();
@@ -415,7 +424,7 @@
             elements.sendButton.textContent = '...';
 
             try {
-                const response = await fetch(`${API_BASE_URL}/api/threads/${currentThreadId}/send-message`, {
+                const response = await authorizedFetch(`${API_BASE_URL}/api/threads/${currentThreadId}/send-message`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ text })
@@ -438,7 +447,7 @@
             elements.replyText.value = 'AI генерира отговор, моля изчакайте...';
 
             try {
-                const response = await fetch(`${API_BASE_URL}/api/generate-reply`, {
+                const response = await authorizedFetch(`${API_BASE_URL}/api/generate-reply`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ threadId: currentThreadId })
@@ -464,7 +473,7 @@
             elements.analyzerResult.textContent = 'Анализирам...';
 
             try {
-                const response = await fetch(`${API_BASE_URL}/api/analyze-thread`, {
+                const response = await authorizedFetch(`${API_BASE_URL}/api/analyze-thread`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ threadId: currentThreadId, question })
@@ -505,7 +514,7 @@
 
             setButtonLoading(elements.broadcastButton, true, 'Изпращам...');
             try {
-                const response = await fetch(`${API_BASE_URL}/api/broadcast`, {
+                const response = await authorizedFetch(`${API_BASE_URL}/api/broadcast`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ threadIds: selectedIds, text: message })
@@ -528,7 +537,7 @@
             elements.statusMessage.textContent = '';
             elements.promptTextarea.value = 'Зареждам текущия промпт...';
             try {
-                const response = await fetch(`${API_BASE_URL}/api/prompt`);
+                const response = await authorizedFetch(`${API_BASE_URL}/api/prompt`);
                 if (!response.ok) throw new Error((await response.json()).error);
                 const data = await response.json();
                 elements.promptTextarea.value = data.prompt || '';
@@ -542,7 +551,7 @@
             setButtonLoading(elements.savePromptButton, true, 'Запазвам...');
             showStatusMessage('Запазвам...');
             try {
-                const response = await fetch(`${API_BASE_URL}/api/prompt`, {
+                const response = await authorizedFetch(`${API_BASE_URL}/api/prompt`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ prompt: newPrompt })


### PR DESCRIPTION
## Summary
- include new `auth.js` module with `refreshToken` and `authorizedFetch`
- retry thread and advert requests after refreshing token on 401
- wire all API calls through a single authorization-aware fetch helper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9111f13c483268639ddc9b9b95308