### PR TITLE
chore: validate thread ids in broadcast

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -144,10 +144,13 @@ export default {
       if (!threadIds || !Array.isArray(threadIds) || threadIds.length === 0 || !text) {
           return jsonResponse({ error: "threadIds (array) and text are required." }, 400);
       }
+      if (!threadIds.every(id => Number.isInteger(Number(id)))) {
+          return jsonResponse({ error: "threadIds must contain only integers." }, 400);
+      }
 
       const accessToken = await getValidAccessToken(env);
       if (!accessToken) return jsonResponse({ error: "Authentication required." }, 401);
-      
+
       let sentCount = 0;
       for (const threadId of threadIds) {
           try {


### PR DESCRIPTION
## Summary
- validate threadIds are integers before broadcasting

## Testing
- `node --check worker.js`


------
https://chatgpt.com/codex/tasks/task_e_68a91242ac848326b044708869b0db92