### PR TITLE
Добавен API маршрут за обяви

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,10 +214,10 @@
                 return advert;
             }
             try {
-                let response = await authorizedFetch(`https://www.olx.bg/api/partner/adverts/${id}`);
+                let response = await authorizedFetch(`${API_BASE_URL}/api/adverts/${id}`);
                 if (response.status === 401) {
                     await refreshToken();
-                    response = await authorizedFetch(`https://www.olx.bg/api/partner/adverts/${id}`);
+                    response = await authorizedFetch(`${API_BASE_URL}/api/adverts/${id}`);
                 }
                 if (!response.ok) throw new Error('Advert fetch failed');
                 const advert = await response.json();

--- a/worker.js
+++ b/worker.js
@@ -41,6 +41,9 @@ export default {
       const sendMatch = path.match(/^\/api\/threads\/(\d+)\/send-message$/);
       if (sendMatch && method === 'POST') return this.sendMessage(request, env, sendMatch[1]);
 
+      const advertMatch = path.match(/^\/api\/adverts\/(\d+)$/);
+      if (advertMatch && method === 'GET') return this.getAdvert(request, env, advertMatch[1]);
+
       if (path === "/api/generate-reply" && method === 'POST') return this.generateReply(request, env);
       if (path === "/api/analyze-thread" && method === 'POST') return this.analyzeThread(request, env);
       if (path === "/api/broadcast" && method === 'POST') return this.broadcastMessage(request, env);
@@ -79,6 +82,16 @@ export default {
     if (!messagesResponse.ok) throw new Error(`OLX API Error [getMessages]: ${messagesResponse.status}`);
     const messagesData = await messagesResponse.json();
     return jsonResponse(messagesData.data);
+  },
+
+  async getAdvert(request, env, advertId) {
+    const accessToken = await getValidAccessToken(env);
+    if (!accessToken) return jsonResponse({ error: "Authentication required." }, 401);
+
+    const advertResponse = await fetch(`https://www.olx.bg/api/partner/adverts/${advertId}`, { headers: { "Authorization": `Bearer ${accessToken}`, "Version": "2.0" } });
+    if (!advertResponse.ok) throw new Error(`OLX API Error [getAdvert]: ${advertResponse.status}`);
+    const advertData = await advertResponse.json();
+    return jsonResponse(advertData);
   },
   
   async generateReply(request, env) {


### PR DESCRIPTION
## Резюме
- Добавен е нов маршрут `GET /api/adverts/:id` във worker.js и функция `getAdvert`
- Интерфейсът вече извлича обяви през `API_BASE_URL` вместо директно от OLX

## Тестване
- `node --check worker.js`
- `npx -y htmlhint index.html`
- `curl -i -H "Origin: https://example.com" https://olx.radilov-k.workers.dev/api/adverts/1` *(неуспех: 403 CONNECT tunnel failed)*


------
https://chatgpt.com/codex/tasks/task_e_68a9181d9f448326a32229e7df7cf352