### PR TITLE
Премахване на refreshToken и 401 проверки

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -5,23 +5,6 @@
     return localStorage.getItem(TOKEN_KEY);
   }
 
-  function setToken(token) {
-    localStorage.setItem(TOKEN_KEY, token);
-  }
-
-  async function refreshToken() {
-    const response = await fetch(`${API_BASE_URL}/api/refresh-token`, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${getToken()}`
-      }
-    });
-    if (!response.ok) throw new Error('Refresh token failed');
-    const data = await response.json();
-    setToken(data.token);
-    return data.token;
-  }
-
   async function authorizedFetch(url, options = {}) {
     const headers = new Headers(options.headers || {});
     const token = getToken();
@@ -30,6 +13,5 @@
     return fetch(url, options);
   }
 
-  window.refreshToken = refreshToken;
   window.authorizedFetch = authorizedFetch;
 })();

--- a/index.html
+++ b/index.html
@@ -215,10 +215,6 @@
             }
             try {
                 let response = await authorizedFetch(`https://www.olx.bg/api/partner/adverts/${id}`);
-                if (response.status === 401) {
-                    await refreshToken();
-                    response = await authorizedFetch(`https://www.olx.bg/api/partner/adverts/${id}`);
-                }
                 if (!response.ok) throw new Error('Advert fetch failed');
                 const advert = await response.json();
                 advertCache.set(id, advert);
@@ -234,10 +230,6 @@
             elements.threadsList.innerHTML = '';
             try {
                 let response = await authorizedFetch(`${API_BASE_URL}/api/threads`);
-                if (response.status === 401) {
-                    await refreshToken();
-                    response = await authorizedFetch(`${API_BASE_URL}/api/threads`);
-                }
                 if (!response.ok) {
                     const errorData = await response.json();
                     throw new Error(`${errorData.error} <a href="${AUTH_URL}">Оторизирайте се отново</a>.`);


### PR DESCRIPTION
## Summary
- премахнат `refreshToken` и експортирането му
- `authorizedFetch` само добавя токен при нужда
- изчистени 401 проверки, които викаха `refreshToken`

## Testing
- `npm test` *(липсва `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a9182cda648326b1d056b95708ffba