### PR TITLE
Премахване на refresh токена и опростяване на заявките

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -5,23 +5,6 @@
     return localStorage.getItem(TOKEN_KEY);
   }
 
-  function setToken(token) {
-    localStorage.setItem(TOKEN_KEY, token);
-  }
-
-  async function refreshToken() {
-    const response = await fetch(`${API_BASE_URL}/api/refresh-token`, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${getToken()}`
-      }
-    });
-    if (!response.ok) throw new Error('Refresh token failed');
-    const data = await response.json();
-    setToken(data.token);
-    return data.token;
-  }
-
   async function authorizedFetch(url, options = {}) {
     const headers = new Headers(options.headers || {});
     const token = getToken();
@@ -29,7 +12,5 @@
     options.headers = headers;
     return fetch(url, options);
   }
-
-  window.refreshToken = refreshToken;
   window.authorizedFetch = authorizedFetch;
 })();

--- a/index.html
+++ b/index.html
@@ -214,11 +214,7 @@
                 return advert;
             }
             try {
-                let response = await authorizedFetch(`${API_BASE_URL}/api/adverts/${id}`);
-                if (response.status === 401) {
-                    await refreshToken();
-                    response = await authorizedFetch(`${API_BASE_URL}/api/adverts/${id}`);
-                }
+                const response = await authorizedFetch(`${API_BASE_URL}/api/adverts/${id}`);
                 if (!response.ok) throw new Error('Advert fetch failed');
                 const advert = await response.json();
                 advertCache.set(id, advert);
@@ -233,11 +229,7 @@
             elements.loader.classList.remove('hidden');
             elements.threadsList.innerHTML = '';
             try {
-                let response = await authorizedFetch(`${API_BASE_URL}/api/threads`);
-                if (response.status === 401) {
-                    await refreshToken();
-                    response = await authorizedFetch(`${API_BASE_URL}/api/threads`);
-                }
+                const response = await authorizedFetch(`${API_BASE_URL}/api/threads`);
                 if (!response.ok) {
                     const errorData = await response.json();
                     throw new Error(`${errorData.error} <a href="${AUTH_URL}">Оторизирайте се отново</a>.`);


### PR DESCRIPTION
## Резюме
- Премахната е функцията `refreshToken` и всички нейни извиквания
- Опростен е `authorizedFetch` до добавяне на токен само при наличие
- Почистени са проверките за статус 401, които извикваха `refreshToken`

## Тестване
- `npm test` *(липсва `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a9193f77048326bc031a637c825f6d