### PR TITLE
Показване на коректни имена и дати в списъка с разговори

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,7 +248,6 @@
                             if (advert && advert.data) {
                                 meta.advertTitle = advert.data.title || meta.advertTitle;
                                 meta.advertCreatedAt = advert.data.created_at || meta.advertCreatedAt;
-                                meta.contactName = advert.data.contact?.name || meta.contactName;
                             } else {
                                 meta.advertTitle = meta.advertTitle || '(невалидна обява)';
                             }
@@ -266,7 +265,7 @@
                     const shortValue = meta.shortName || meta.advertTitle || '';
                     const orderStatus = meta.orderStatus || 'pending';
                     const shipping = meta.shipping || '';
-                    const lastDate = formatDate(thread.last_message_date);
+                    const lastDate = formatDate(thread.last_message_date || thread.last_message?.created_at || thread.last_message?.date);
                     if (!isRead) threadElement.classList.add('unread');
 
                     const interlocutorName = meta.contactName || thread.interlocutor?.name || 'Неизвестен потребител';


### PR DESCRIPTION
## Резюме
- предотвратено презаписване на името на клиента с името от обявата
- датата на последното съобщение се извлича и от обекта `last_message`

## Тестване
- `npm test` *(очаквано неуспешно: липсва package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a91b1aced48326b5746198f454a5bb