### PR TITLE
Показване на името на клиента в списъка с разговори

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,7 +277,7 @@
                     const lastDate = formatDate(lastDateRaw);
                     if (!isRead) threadElement.classList.add('unread');
 
-                    const interlocutorName = meta.contactName || thread.interlocutor?.name || 'Неизвестен потребител';
+                    const interlocutorName = meta.contactName || 'Неизвестен потребител';
                     const advertTitle = meta.advertTitle || '';
 
                     threadElement.innerHTML = `
@@ -424,7 +424,9 @@
                     const meta = getThreadMeta(threadId);
                     const lastMsg = messages[messages.length - 1];
                     meta.lastDate = lastMsg?.created_at || lastMsg?.date || meta.lastDate;
-                    const clientMsg = messages.find(m => m.type === 'received');
+                    const clientMsg = messages.find(m => m.type === 'received') ||
+                        messages.find(m => m.type !== 'sent') ||
+                        messages[0];
                     if (clientMsg) {
                         meta.contactName = clientMsg.user_name || clientMsg.user?.name || clientMsg.sender?.name || meta.contactName;
                     }

--- a/worker.js
+++ b/worker.js
@@ -132,7 +132,9 @@ export default {
       if (messagesRes.ok) {
         const messagesData = await messagesRes.json();
         const msgs = messagesData.data || [];
-        const clientMsg = msgs.find(m => m.type === 'received');
+        const clientMsg = msgs.find(m => m.type === 'received') ||
+          msgs.find(m => m.type !== 'sent') ||
+          msgs[0];
         if (clientMsg) {
           contactName = clientMsg.user_name || clientMsg.user?.name || clientMsg.sender?.name || contactName;
         }


### PR DESCRIPTION
## Резюме
- Изчистено е използването на името на собственика при визуализиране на разговори и е добавен коректен товарител за име на клиента.
- Приложена е по-устойчива логика за извличане на името на клиента от съобщенията.

## Тестване
- `node --check worker.js`
- `npx -y htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68a9280736e08326aab863ebf9b1d048