### PR TITLE
Маркиране на разговорите като прочетени при преглед

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,8 +440,14 @@
                     renderChatTags(threadId);
                     const threadEl = document.querySelector(`.thread-item[data-thread-id="${threadId}"]`);
                     if (threadEl) {
+                        threadEl.classList.remove('unread');
                         const dateEl = threadEl.querySelector('.last-date');
                         if (dateEl) dateEl.textContent = `Последно: ${formatDate(meta.lastDate)}`;
+                    }
+                    try {
+                        await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, { method: 'POST' });
+                    } catch (err) {
+                        console.warn('Неуспешно маркиране на прочетено', err);
                     }
                 }
             } catch (error) {


### PR DESCRIPTION
## Резюме
- при зареждане на съобщенията премахваме `unread` класа от съответния разговор
- добавена е заявка към API, която маркира разговора като прочетен на сървъра

## Тестване
- `npm test` *(очакван провал: липсва `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a933aa17fc832682e57c873141c5ea