### PR TITLE
Fix unread state reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,9 +426,9 @@
                     threadElement.className = 'thread-item';
                     threadElement.dataset.threadId = thread.id;
 
-                    const isRead = thread.unread_count === 0;
-                    const shortValue = meta.shortName || meta.advertTitle || '';
                     const lastDateRaw = meta.lastDate || thread.last_message_date || thread.last_message?.created_at || thread.last_message?.date || thread.updated_at;
+                    const isRead = thread.unread_count === 0 || (meta.lastRead && new Date(meta.lastRead) >= new Date(lastDateRaw));
+                    const shortValue = meta.shortName || meta.advertTitle || '';
                     const lastDate = formatDate(lastDateRaw);
                     if (!isRead) threadElement.classList.add('unread');
                     if (autoReplyEnabled && !isRead && meta.lastAutoReply !== lastDateRaw) {
@@ -563,7 +563,10 @@
                 const badge = threadEl.querySelector('.badge');
                 if (badge) badge.remove();
             }
-            authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, { method: 'POST' })
+            const meta = getThreadMeta(threadId);
+            meta.lastRead = new Date().toISOString();
+            saveThreadMeta(threadId, meta);
+            authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, { method: 'POST', keepalive: true })
                 .catch(err => console.warn('Неуспешно маркиране на прочетено', err));
         }
 

--- a/worker.js
+++ b/worker.js
@@ -44,6 +44,9 @@ export default {
       const sendMatch = path.match(/^\/api\/threads\/(\d+)\/send-message$/);
       if (sendMatch && method === 'POST') return this.sendMessage(request, env, sendMatch[1]);
 
+      const markReadMatch = path.match(/^\/api\/threads\/(\d+)\/mark-read$/);
+      if (markReadMatch && method === 'POST') return this.markThreadRead(request, env, markReadMatch[1]);
+
       const advertMatch = path.match(/^\/api\/adverts\/(\d+)$/);
       if (advertMatch && method === 'GET') return this.getAdvert(request, env, advertMatch[1]);
 
@@ -208,6 +211,19 @@ export default {
       });
 
       if (!response.ok) throw new Error(`OLX API Error [sendMessage]: ${response.status} - ${await response.text()}`);
+      return jsonResponse({ success: true });
+  },
+
+  async markThreadRead(request, env, threadId) {
+      const accessToken = await getValidAccessToken(env);
+      if (!accessToken) return jsonResponse({ error: "Authentication required." }, 401);
+
+      const response = await fetch(`https://www.olx.bg/api/partner/threads/${threadId}/mark-read`, {
+          method: 'POST',
+          headers: { 'Authorization': `Bearer ${accessToken}`, 'Version': '2.0' }
+      });
+
+      if (!response.ok) throw new Error(`OLX API Error [markThreadRead]: ${response.status}`);
       return jsonResponse({ success: true });
   },
 


### PR DESCRIPTION
## Summary
- persist read timestamp to avoid thread reappearing as unread
- add backend endpoint to mark threads as read via OLX API

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a97aa992408326be69bc47445eefd5