### PR TITLE
Използване на името от данни за доставка

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@
 
                     const conversationId = thread.id;
                     const advertTitle = meta.advertTitle || '';
-                    const displayName = meta.contactName || thread.contact_name || conversationId;
+                    const displayName = meta.deliveryInfo?.name || meta.contactName || thread.contact_name || conversationId;
                     const shortTitle = getFirstWords(advertTitle, 2);
 
                     threadElement.innerHTML = `
@@ -530,7 +530,7 @@
                         const dateEl = threadEl.querySelector('.last-date');
                         if (dateEl) dateEl.textContent = `Последно: ${formatDate(meta.lastDate)}`;
                         const nameEl = threadEl.querySelector('.conversation-id');
-                        if (nameEl) nameEl.textContent = meta.contactName || threadId;
+                        if (nameEl) nameEl.textContent = meta.deliveryInfo?.name || meta.contactName || threadId;
                     }
                     markThreadRead(threadId);
                 }
@@ -758,6 +758,10 @@
                 if (tagContainer) {
                     tagContainer.innerHTML = createTagButtons(meta);
                     attachTagButtonEvents(tagContainer, meta, threadId);
+                }
+                const nameEl = threadEl.querySelector('.conversation-id');
+                if (nameEl) {
+                    nameEl.textContent = meta.deliveryInfo?.name || meta.contactName || threadId;
                 }
             }
             if (currentThreadId === threadId) {


### PR DESCRIPTION
## Резюме
- показване на името от `tag-btn info` при наличност
- синхронизиране на заглавието на разговора след запазване на данните

## Тестване
- `npm test` *(очаквано грешка: липсващ package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca523f2088326b214c389253bc564