### PR TITLE
Sticky хедър за бутоните в чат прозореца

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,10 +54,18 @@
         #back-button, #close-settings-button { margin: 5px; padding: 5px 10px; border: 1px solid #ccc; background: none; border-radius: 5px; cursor: pointer; }
         #back-button { display: none; }
 
+        #chat-header {
+            position: sticky;
+            top: 0;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 5px 10px;
+            background: rgba(255, 255, 255, 0.6);
+            z-index: 1001;
+        }
+
         #close-chat-button {
-            position: fixed;
-            top: 10px;
-            right: 10px;
             width: 30px;
             height: 30px;
             border: none;
@@ -66,8 +74,8 @@
             color: #fff;
             cursor: pointer;
             opacity: 0.7;
-            z-index: 1001;
         }
+
         #close-chat-button:hover { opacity: 1; }
 
         /* --- Main Content Area --- */
@@ -146,6 +154,7 @@
         body.dark .thread-item-info p, body.dark .thread-item-info small { color: var(--text-light); }
         body.dark .thread-item-info p { color: var(--text-dark); }
         body.dark .tag-buttons .tag-btn { background-color: #2c2c2c; border-color: #333; color: var(--text-light); }
+        body.dark #chat-header { background: rgba(18, 18, 18, 0.6); }
         body.dark #analyzer-section { border-bottom: 1px solid #333; background-color: #1e1e1e; }
         body.dark #analyzer-input { border: 1px solid #333; background-color: #2c2c2c; color: var(--text-dark); }
         body.dark #analyzer-result { background-color: #2d333b; color: var(--text-dark); }
@@ -160,8 +169,6 @@
     </style>
 </head>
 <body>
-
-    <button id="close-chat-button" class="hidden">✖</button>
 
     <!-- SIDEBAR: Списък с разговори и инструменти за групови съобщения -->
     <div id="sidebar">
@@ -193,6 +200,10 @@
             <!-- Изглед за чат -->
             <div id="chat-view" class="hidden" style="display: flex; flex-direction: column; height: 100%;">
                 <button id="back-button" class="hidden">⬅️ Назад</button>
+                <div id="chat-header" class="chat-header">
+                    <div id="chat-tags" class="tag-buttons"></div>
+                    <button id="close-chat-button" class="hidden">✖</button>
+                </div>
                 <div id="analyzer-section">
                     <p>AI Анализатор на разговора</p>
                     <div class="analyzer-input-group">
@@ -201,7 +212,6 @@
                     </div>
                     <div id="analyzer-result" class="hidden"></div>
                 </div>
-                <div id="chat-tags" class="tag-buttons"></div>
                 <div id="messages-view"></div>
                 <div id="reply-area">
                     <textarea id="reply-text" rows="1" placeholder="Напишете отговор..."></textarea>


### PR DESCRIPTION
## Обобщение
- Преместени tag бутоните и бутона за затваряне в нов sticky хедър
- Добавен полупрозрачен фон и поддръжка за тъмна тема

## Тестване
- `npm test` *(грешка: липсва package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca712bb5c8326bbc845eb2a0f901f