### PR TITLE
Използване на името от данни за доставка

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@
 
                     const conversationId = thread.id;
                     const advertTitle = meta.advertTitle || '';
-                    const displayName = meta.contactName || thread.contact_name || conversationId;
+                    const displayName = getDisplayName(meta, conversationId, thread.contact_name);
                     const shortTitle = getFirstWords(advertTitle, 2);
 
                     threadElement.innerHTML = `
@@ -520,7 +520,7 @@
                     const clientMsg = messages.find(m => m.type === 'received') ||
                         messages.find(m => m.type !== 'sent') ||
                         messages[0];
-                    if (clientMsg) {
+                    if (clientMsg && !(meta.deliveryInfo && meta.deliveryInfo.name)) {
                         meta.contactName = clientMsg.user_name || clientMsg.user?.name || clientMsg.sender?.name || meta.contactName;
                     }
                     saveThreadMeta(threadId, meta);
@@ -530,7 +530,7 @@
                         const dateEl = threadEl.querySelector('.last-date');
                         if (dateEl) dateEl.textContent = `Последно: ${formatDate(meta.lastDate)}`;
                         const nameEl = threadEl.querySelector('.conversation-id');
-                        if (nameEl) nameEl.textContent = meta.contactName || threadId;
+                        if (nameEl) nameEl.textContent = getDisplayName(meta, threadId);
                     }
                     markThreadRead(threadId);
                 }
@@ -759,6 +759,10 @@
                     tagContainer.innerHTML = createTagButtons(meta);
                     attachTagButtonEvents(tagContainer, meta, threadId);
                 }
+                const nameEl = threadEl.querySelector('.conversation-id');
+                if (nameEl) {
+                    nameEl.textContent = getDisplayName(meta, threadId);
+                }
             }
             if (currentThreadId === threadId) {
                 renderChatTags(threadId);
@@ -807,6 +811,9 @@
                     phone: document.getElementById('info-phone').value.trim(),
                     address: document.getElementById('info-address').value.trim()
                 };
+                if (meta.deliveryInfo.name) {
+                    meta.contactName = meta.deliveryInfo.name;
+                }
                 saveThreadMeta(threadId, meta);
                 updateThreadTagButtons(threadId);
             });
@@ -890,6 +897,10 @@
 
         function saveThreadMeta(id, data) {
             localStorage.setItem(`thread_meta_${id}`, JSON.stringify(data));
+        }
+
+        function getDisplayName(meta, threadId, fallbackName = '') {
+            return (meta.deliveryInfo && meta.deliveryInfo.name) || meta.contactName || fallbackName || threadId;
         }
 
         function getFirstWords(text, count) {


### PR DESCRIPTION
## Резюме
- показване на името от данните за доставка в списъка и при обновяване
- синхронизиране на `contactName` при запазване на данните
- централизирана функция `getDisplayName`

## Тестване
- `npm test` *(очаквано грешка: липсва package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca523f2088326b214c389253bc564