### PR TITLE
Използване на името от данни за доставка

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@
 
                     const conversationId = thread.id;
                     const advertTitle = meta.advertTitle || '';
-                    const displayName = meta.contactName || thread.contact_name || conversationId;
+                    const displayName = getDisplayName(meta, conversationId, thread.contact_name);
                     const shortTitle = getFirstWords(advertTitle, 2);
 
                     threadElement.innerHTML = `
@@ -520,8 +520,9 @@
                     const clientMsg = messages.find(m => m.type === 'received') ||
                         messages.find(m => m.type !== 'sent') ||
                         messages[0];
-                    if (clientMsg) {
-                        meta.contactName = clientMsg.user_name || clientMsg.user?.name || clientMsg.sender?.name || meta.contactName;
+                    if (clientMsg && !(meta.deliveryInfo && meta.deliveryInfo.name)) {
+                        const rawName = clientMsg.user_name || clientMsg.user?.name || clientMsg.sender?.name;
+                        if (rawName) meta.contactName = getFirstWords(rawName, 2);
                     }
                     saveThreadMeta(threadId, meta);
                     renderChatTags(threadId);
@@ -530,7 +531,7 @@
                         const dateEl = threadEl.querySelector('.last-date');
                         if (dateEl) dateEl.textContent = `Последно: ${formatDate(meta.lastDate)}`;
                         const nameEl = threadEl.querySelector('.conversation-id');
-                        if (nameEl) nameEl.textContent = meta.contactName || threadId;
+                        if (nameEl) nameEl.textContent = getDisplayName(meta, threadId);
                     }
                     markThreadRead(threadId);
                 }
@@ -759,6 +760,10 @@
                     tagContainer.innerHTML = createTagButtons(meta);
                     attachTagButtonEvents(tagContainer, meta, threadId);
                 }
+                const nameEl = threadEl.querySelector('.conversation-id');
+                if (nameEl) {
+                    nameEl.textContent = getDisplayName(meta, threadId);
+                }
             }
             if (currentThreadId === threadId) {
                 renderChatTags(threadId);
@@ -807,6 +812,9 @@
                     phone: document.getElementById('info-phone').value.trim(),
                     address: document.getElementById('info-address').value.trim()
                 };
+                if (meta.deliveryInfo.name) {
+                    meta.contactName = getFirstWords(meta.deliveryInfo.name, 2);
+                }
                 saveThreadMeta(threadId, meta);
                 updateThreadTagButtons(threadId);
             });
@@ -890,6 +898,11 @@
 
         function saveThreadMeta(id, data) {
             localStorage.setItem(`thread_meta_${id}`, JSON.stringify(data));
+        }
+
+        function getDisplayName(meta, threadId, fallbackName = '') {
+            const raw = (meta.deliveryInfo && meta.deliveryInfo.name) || meta.contactName || fallbackName || threadId;
+            return getFirstWords(raw, 2);
         }
 
         function getFirstWords(text, count) {


### PR DESCRIPTION
## Резюме
- ограничаване на показваното име до първите две думи
- записване на съкратеното име при запазване на "Данни за доставка"
- функция `getDisplayName` връща само първите две думи от наличните данни

## Тестване
- `npm test` *(очаквано грешка: липсва package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aca523f2088326b214c389253bc564