### PR TITLE
Показване на име от бутона info за разговор

### DIFF
--- a/index.html
+++ b/index.html
@@ -836,8 +836,15 @@
                     phone: document.getElementById('info-phone').value.trim(),
                     address: document.getElementById('info-address').value.trim()
                 };
+                const nameForDisplay = getFirstWords(meta.deliveryInfo.name, 2);
+                if (nameForDisplay) meta.contactName = nameForDisplay;
                 saveThreadMeta(threadId, meta);
                 updateThreadTagButtons(threadId);
+                const threadEl = document.querySelector(`.thread-item[data-thread-id="${threadId}"]`);
+                if (threadEl) {
+                    const nameEl = threadEl.querySelector('.conversation-id');
+                    if (nameEl) nameEl.textContent = meta.contactName || threadId;
+                }
             });
         }
 


### PR DESCRIPTION
## Резюме
- Запазване и показване на първите две думи от полето "Имена" в info таговете
- Актуализиране на списъка с разговори при промяна на името

## Тестване
- `npm test` (очаквано: липсващ package.json)


------
https://chatgpt.com/codex/tasks/task_e_68acc59aa4888326b2771a56b6b2a92d