### PR TITLE
Показване на име от бутона info за разговор

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,6 +416,15 @@
 
                 for (const thread of threads) {
                     const meta = getThreadMeta(thread.id);
+
+                    if (!meta.contactName && meta.deliveryInfo && meta.deliveryInfo.name) {
+                        const nameForDisplay = getFirstWords(meta.deliveryInfo.name, 2);
+                        if (nameForDisplay) {
+                            meta.contactName = nameForDisplay;
+                            saveThreadMeta(thread.id, meta);
+                        }
+                    }
+
                     if (thread.advert_id) {
                         try {
                             const advert = await getAdvert(thread.advert_id);
@@ -531,7 +540,9 @@
                         messages.find(m => m.type !== 'sent') ||
                         messages[0];
                     if (clientMsg) {
-                        meta.contactName = clientMsg.user_name || clientMsg.user?.name || clientMsg.sender?.name || meta.contactName;
+                        const nameCandidate = clientMsg.user_name || clientMsg.user?.name || clientMsg.sender?.name;
+                        const nameForDisplay = getFirstWords(nameCandidate, 2);
+                        if (nameForDisplay) meta.contactName = nameForDisplay;
                     }
                     saveThreadMeta(threadId, meta);
                     renderChatTags(threadId);
@@ -836,8 +847,15 @@
                     phone: document.getElementById('info-phone').value.trim(),
                     address: document.getElementById('info-address').value.trim()
                 };
+                const nameForDisplay = getFirstWords(meta.deliveryInfo.name, 2);
+                if (nameForDisplay) meta.contactName = nameForDisplay;
                 saveThreadMeta(threadId, meta);
                 updateThreadTagButtons(threadId);
+                const threadEl = document.querySelector(`.thread-item[data-thread-id="${threadId}"]`);
+                if (threadEl) {
+                    const nameEl = threadEl.querySelector('.conversation-id');
+                    if (nameEl) nameEl.textContent = meta.contactName || threadId;
+                }
             });
         }
 


### PR DESCRIPTION
## Резюме
- Използване на запазеното име от tag-btn info за автоматично показване вместо ID
- Прехващане на първите две думи от името и при зареждане на съобщенията

## Тестване
- `npm test` (очаквано: липсващ package.json)

------
https://chatgpt.com/codex/tasks/task_e_68acc59aa4888326b2771a56b6b2a92d