### PR TITLE
Добавяне на сортиране на разговори и автоматично зануляване на отметката „Изпратено“

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,13 @@
                 <button id="settings-button" style="margin-left: 5px;">⚙️</button>
             </div>
         </div>
+        <div class="sidebar-sort">
+            <select id="sort-select">
+                <option value="date">По дата</option>
+                <option value="unsent">Неизпратени</option>
+                <option value="noanswer">Без отговор</option>
+            </select>
+        </div>
         <div id="loader">Зареждам разговори...</div>
         <div id="threads-list"></div>
         <div id="broadcast-section" class="hidden">
@@ -296,6 +303,7 @@
             mainContent: document.getElementById('main-content'),
             backButton: document.getElementById('back-button'),
             closeChatButton: document.getElementById('close-chat-button'),
+            sortSelect: document.getElementById('sort-select'),
         };
 
         // --- EVENT LISTENERS ---
@@ -309,6 +317,7 @@
             elements.refreshButton.addEventListener('click', fetchThreads);
             elements.settingsButton.addEventListener('click', showSettingsView);
             elements.selectAllCheckbox.addEventListener('change', handleSelectAll);
+            elements.sortSelect.addEventListener('change', fetchThreads);
             elements.threadsList.addEventListener('change', e => {
                 if (e.target.classList.contains('thread-checkbox')) updateBroadcastCounter();
             });
@@ -414,6 +423,10 @@
                     return;
                 }
 
+                const option = elements.sortSelect.value;
+                const now = Date.now();
+                const processed = [];
+
                 for (const thread of threads) {
                     const meta = getThreadMeta(thread.id);
 
@@ -421,7 +434,6 @@
                         const nameForDisplay = getFirstWords(meta.deliveryInfo.name, 2);
                         if (nameForDisplay) {
                             meta.contactName = nameForDisplay;
-                            saveThreadMeta(thread.id, meta);
                         }
                     }
 
@@ -437,21 +449,40 @@
                         } catch (err) {
                             meta.advertTitle = meta.advertTitle || '(невалидна обява)';
                         }
-                        saveThreadMeta(thread.id, meta);
                     }
 
-                    const threadElement = document.createElement('div');
-                    threadElement.className = 'thread-item';
-                    threadElement.dataset.threadId = thread.id;
-
                     const lastDateRaw = meta.lastDate || thread.last_message_date || thread.last_message?.created_at || thread.last_message?.date || thread.updated_at;
+                    const lastMsgType = meta.lastSenderType || thread.last_message?.type;
+                    if (lastMsgType) meta.lastSenderType = lastMsgType;
                     const isRead = thread.unread_count === 0 || (meta.lastRead && new Date(meta.lastRead) >= new Date(lastDateRaw));
                     const lastDate = formatDate(lastDateRaw);
-                    if (!isRead) threadElement.classList.add('unread');
+
+                    if (meta.checked && meta.checkedAt) {
+                        const lastTime = new Date(lastDateRaw).getTime();
+                        const checkTime = new Date(meta.checkedAt).getTime();
+                        if (lastTime - checkTime > 48 * 60 * 60 * 1000) {
+                            meta.checked = false;
+                            meta.checkedAt = null;
+                        }
+                    }
+
                     if (autoReplyEnabled && !isRead && meta.lastAutoReply !== lastDateRaw) {
                         autoReply(thread.id);
                         meta.lastAutoReply = lastDateRaw;
-                        saveThreadMeta(thread.id, meta);
+                    }
+
+                    saveThreadMeta(thread.id, meta);
+                    processed.push({ thread, meta, lastDateRaw, isRead, lastDate });
+                }
+
+                processed.sort((a, b) => new Date(b.lastDateRaw) - new Date(a.lastDateRaw));
+
+                for (const { thread, meta, lastDateRaw, isRead, lastDate } of processed) {
+                    const within48 = now - new Date(lastDateRaw).getTime() <= 48 * 60 * 60 * 1000;
+                    if (option === 'unsent') {
+                        if (!(within48 && !meta.checked && (meta.redMark || meta.blueMark))) continue;
+                    } else if (option === 'noanswer') {
+                        if (!(within48 && !meta.checked && meta.lastSenderType === 'received')) continue;
                     }
 
                     const conversationId = thread.id;
@@ -462,6 +493,11 @@
                         saveThreadMeta(thread.id, meta);
                     }
                     const shortTitle = getFirstWords(advertTitle, 2);
+
+                    const threadElement = document.createElement('div');
+                    threadElement.className = 'thread-item';
+                    threadElement.dataset.threadId = thread.id;
+                    if (!isRead) threadElement.classList.add('unread');
 
                     threadElement.innerHTML = `
                         <input type="checkbox" class="thread-checkbox" data-id="${thread.id}" name="thread-checkbox-${thread.id}">
@@ -570,6 +606,11 @@
                     const meta = getThreadMeta(threadId);
                     const lastMsg = messages[messages.length - 1];
                     meta.lastDate = lastMsg?.created_at || lastMsg?.date || meta.lastDate;
+                    meta.lastSenderType = lastMsg?.type || meta.lastSenderType;
+                    if (meta.checked && meta.checkedAt && meta.lastDate && (new Date(meta.lastDate) - new Date(meta.checkedAt) > 48 * 60 * 60 * 1000)) {
+                        meta.checked = false;
+                        meta.checkedAt = null;
+                    }
                     const clientMsg = messages.find(m => m.type === 'received') ||
                         messages.find(m => m.type !== 'sent') ||
                         messages[0];
@@ -806,6 +847,7 @@
             checkBtn.addEventListener('click', async e => {
                 e.stopPropagation();
                 meta.checked = !meta.checked;
+                meta.checkedAt = meta.checked ? new Date().toISOString() : null;
                 saveThreadMeta(threadId, meta);
                 updateThreadTagButtons(threadId);
                 if (meta.checked) {


### PR DESCRIPTION
## Обобщение
- добавен е падащ списък за избор на подреждане на разговорите
- внедрено е филтриране по "Неизпратени" и "Без отговор" и автоматично премахване на отметката „Изпратено“ след 48 часа
- записва се времето на маркиране „Изпратено“ за коректно зануляване при нови съобщения

## Тестване
- `npm test` *(липсва `package.json`, тестове не са изпълнени)*

------
https://chatgpt.com/codex/tasks/task_e_68adf802367c8326927fcefa807f8701