### PR TITLE
Handle errors when marking threads as read

### DIFF
--- a/index.html
+++ b/index.html
@@ -641,18 +641,29 @@
             elements.replyText.style.height = Math.max(elements.replyText.scrollHeight, minHeight) + 'px';
         }
 
-        function markThreadRead(threadId) {
+        async function markThreadRead(threadId) {
+            try {
+                const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, { method: 'POST', keepalive: true });
+                if (!resp.ok) {
+                    console.warn('Неуспешно маркиране на прочетено', resp.status, resp.statusText);
+                    return;
+                }
+            } catch (err) {
+                console.warn('Неуспешно маркиране на прочетено', err);
+                return;
+            }
+
             const threadEl = document.querySelector(`.thread-item[data-thread-id="${threadId}"]`);
             if (threadEl) {
                 threadEl.classList.remove('unread');
                 const badge = threadEl.querySelector('.badge');
                 if (badge) badge.remove();
+            } else {
+                fetchThreads();
             }
             const meta = getThreadMeta(threadId);
             meta.lastRead = new Date().toISOString();
             saveThreadMeta(threadId, meta);
-            authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, { method: 'POST', keepalive: true })
-                .catch(err => console.warn('Неуспешно маркиране на прочетено', err));
         }
 
         async function sendMessage() {


### PR DESCRIPTION
## Summary
- make `markThreadRead` asynchronous and check server response
- avoid updating lastRead on failure and refresh thread list when missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1092d7988326b8ce2adf6c28a866