### PR TITLE
Актуализация на метаданните за разговорите

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,10 +451,11 @@
                         }
                     }
 
-                    const lastDateRaw = meta.lastDate || thread.last_message_date || thread.last_message?.created_at || thread.last_message?.date || thread.updated_at;
+                    meta.lastDate = thread.last_message_date || thread.last_message?.created_at || thread.updated_at;
+                    const lastDateRaw = meta.lastDate || thread.last_message?.date || thread.updated_at;
                     const lastMsgType = meta.lastSenderType || thread.last_message?.type;
                     if (lastMsgType) meta.lastSenderType = lastMsgType;
-                    const isRead = thread.unread_count === 0 || (meta.lastRead && new Date(meta.lastRead) >= new Date(lastDateRaw));
+                    const isRead = thread.unread_count === 0 || (meta.lastRead && new Date(meta.lastRead) >= new Date(meta.lastDate));
                     const lastDate = formatDate(lastDateRaw);
 
                     if (meta.checked && meta.checkedAt) {


### PR DESCRIPTION
## Summary
- обновяване на `lastDate` в `fetchThreads` за по-точна дата на последно съобщение
- използване на `saveThreadMeta` за запазване на метаданните с новата дата
- прецизиране на изчисляването на `isRead` спрямо актуализираната последна дата

## Testing
- `npm test` *(очакван провал: липсва package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae10aa03408326ba68d3a21f90170f