### PR TITLE
Добавяне на обграждащ try в fetchThreads

### DIFF
--- a/index.html
+++ b/index.html
@@ -415,137 +415,138 @@
         }
 
         async function fetchThreads(force = false) {
-            elements.loader.classList.remove('hidden');
-            elements.threadsList.innerHTML = '';
+            try {
+                elements.loader.classList.remove('hidden');
+                elements.threadsList.innerHTML = '';
 
-            let threads = null;
-            if (!force) {
-                const cached = loadThreadsFromCache();
-                if (cached && Date.now() - cached.timestamp < THREADS_TTL) {
-                    threads = cached.data;
-                }
-            }
-
-            if (!threads) {
-                try {
-                    const response = await authorizedFetch(`${API_BASE_URL}/api/threads`);
-                    if (!response.ok) {
-                        const errorData = await response.json();
-                        throw new Error(`${errorData.error} <a href="${AUTH_URL}">Оторизирайте се отново</a>.`);
+                let threads = null;
+                if (!force) {
+                    const cached = loadThreadsFromCache();
+                    if (cached && Date.now() - cached.timestamp < THREADS_TTL) {
+                        threads = cached.data;
                     }
-                    threads = await response.json();
-                    saveThreadsToCache(threads);
-                } catch (error) {
-                    elements.threadsList.innerHTML = `<p style="padding: 15px;">${error.message}</p>`;
+                }
+
+                if (!threads) {
+                    try {
+                        const response = await authorizedFetch(`${API_BASE_URL}/api/threads`);
+                        if (!response.ok) {
+                            const errorData = await response.json();
+                            throw new Error(`${errorData.error} <a href="${AUTH_URL}">Оторизирайте се отново</a>.`);
+                        }
+                        threads = await response.json();
+                        saveThreadsToCache(threads);
+                    } catch (error) {
+                        elements.threadsList.innerHTML = `<p style="padding: 15px;">${error.message}</p>`;
+                        return;
+                    }
+                }
+
+                if (!threads || threads.length === 0) {
+                    elements.threadsList.innerHTML = '<p style="padding: 15px;">Няма намерени разговори.</p>';
                     return;
                 }
-            }
 
-            if (!threads || threads.length === 0) {
-                elements.threadsList.innerHTML = '<p style="padding: 15px;">Няма намерени разговори.</p>';
-                return;
-            }
+                const option = elements.sortSelect.value;
+                const now = Date.now();
+                const processed = [];
 
-            const option = elements.sortSelect.value;
-            const now = Date.now();
-            const processed = [];
+                for (const thread of threads) {
+                    const meta = getThreadMeta(thread.id);
 
-            for (const thread of threads) {
-                const meta = getThreadMeta(thread.id);
-
-                    if (!meta.contactName && meta.deliveryInfo && meta.deliveryInfo.name) {
-                        const nameForDisplay = getFirstWords(meta.deliveryInfo.name, 2);
-                        if (nameForDisplay) {
-                            meta.contactName = nameForDisplay;
+                        if (!meta.contactName && meta.deliveryInfo && meta.deliveryInfo.name) {
+                            const nameForDisplay = getFirstWords(meta.deliveryInfo.name, 2);
+                            if (nameForDisplay) {
+                                meta.contactName = nameForDisplay;
+                            }
                         }
-                    }
 
-                    if (thread.advert_id) {
-                        try {
-                            const advert = await getAdvert(thread.advert_id);
-                            if (advert && advert.data) {
-                                meta.advertTitle = advert.data.title || meta.advertTitle;
-                                meta.advertCreatedAt = advert.data.created_at || meta.advertCreatedAt;
-                            } else {
+                        if (thread.advert_id) {
+                            try {
+                                const advert = await getAdvert(thread.advert_id);
+                                if (advert && advert.data) {
+                                    meta.advertTitle = advert.data.title || meta.advertTitle;
+                                    meta.advertCreatedAt = advert.data.created_at || meta.advertCreatedAt;
+                                } else {
+                                    meta.advertTitle = meta.advertTitle || '(невалидна обява)';
+                                }
+                            } catch (err) {
                                 meta.advertTitle = meta.advertTitle || '(невалидна обява)';
                             }
-                        } catch (err) {
-                            meta.advertTitle = meta.advertTitle || '(невалидна обява)';
                         }
-                    }
 
-                    meta.lastDate = thread.last_message_date || thread.last_message?.created_at || thread.updated_at;
-                    const lastDateRaw = meta.lastDate || thread.last_message?.date || thread.updated_at;
-                    const lastMsgType = meta.lastSenderType || thread.last_message?.type;
-                    if (lastMsgType) meta.lastSenderType = lastMsgType;
-                    const isRead = thread.unread_count === 0 || (meta.lastRead && new Date(meta.lastRead) >= new Date(meta.lastDate));
-                    const lastDate = formatDate(lastDateRaw);
+                        meta.lastDate = thread.last_message_date || thread.last_message?.created_at || thread.updated_at;
+                        const lastDateRaw = meta.lastDate || thread.last_message?.date || thread.updated_at;
+                        const lastMsgType = meta.lastSenderType || thread.last_message?.type;
+                        if (lastMsgType) meta.lastSenderType = lastMsgType;
+                        const isRead = thread.unread_count === 0 || (meta.lastRead && new Date(meta.lastRead) >= new Date(meta.lastDate));
+                        const lastDate = formatDate(lastDateRaw);
 
-                    if (meta.checked && meta.checkedAt) {
-                        const lastTime = new Date(lastDateRaw).getTime();
-                        const checkTime = new Date(meta.checkedAt).getTime();
-                        if (lastTime - checkTime > 48 * 60 * 60 * 1000) {
-                            meta.checked = false;
-                            meta.checkedAt = null;
+                        if (meta.checked && meta.checkedAt) {
+                            const lastTime = new Date(lastDateRaw).getTime();
+                            const checkTime = new Date(meta.checkedAt).getTime();
+                            if (lastTime - checkTime > 48 * 60 * 60 * 1000) {
+                                meta.checked = false;
+                                meta.checkedAt = null;
+                            }
                         }
-                    }
 
-                    if (autoReplyEnabled && !isRead && meta.lastAutoReply !== lastDateRaw) {
-                        autoReply(thread.id);
-                        meta.lastAutoReply = lastDateRaw;
-                    }
+                        if (autoReplyEnabled && !isRead && meta.lastAutoReply !== lastDateRaw) {
+                            autoReply(thread.id);
+                            meta.lastAutoReply = lastDateRaw;
+                        }
 
-                    saveThreadMeta(thread.id, meta);
-                    processed.push({ thread, meta, lastDateRaw, isRead, lastDate });
-                }
-
-                processed.sort((a, b) => new Date(b.lastDateRaw) - new Date(a.lastDateRaw));
-
-                for (const { thread, meta, lastDateRaw, isRead, lastDate } of processed) {
-                    const within48 = now - new Date(lastDateRaw).getTime() <= 48 * 60 * 60 * 1000;
-                    if (option === 'unsent') {
-                        if (!(within48 && !meta.checked && (meta.redMark || meta.blueMark))) continue;
-                    } else if (option === 'noanswer') {
-                        if (!(within48 && !meta.checked && meta.lastSenderType === 'received')) continue;
-                    }
-
-                    const conversationId = thread.id;
-                    const advertTitle = meta.advertTitle || '';
-                    const displayName = meta.contactName || getFirstWords(meta.deliveryInfo?.name, 2) || thread.contact_name || conversationId;
-                    if (!meta.contactName && meta.deliveryInfo?.name) {
-                        meta.contactName = getFirstWords(meta.deliveryInfo.name, 2);
                         saveThreadMeta(thread.id, meta);
+                        processed.push({ thread, meta, lastDateRaw, isRead, lastDate });
                     }
-                    const shortTitle = getFirstWords(advertTitle, 2);
 
-                    const threadElement = document.createElement('div');
-                    threadElement.className = 'thread-item';
-                    threadElement.dataset.threadId = thread.id;
-                    if (!isRead) threadElement.classList.add('unread');
+                    processed.sort((a, b) => new Date(b.lastDateRaw) - new Date(a.lastDateRaw));
 
-                    threadElement.innerHTML = `
-                        <input type="checkbox" class="thread-checkbox" data-id="${thread.id}" name="thread-checkbox-${thread.id}">
-                        <div class="thread-item-info">
-                            <p><span class="conversation-id-wrapper"><span class="conversation-id">${displayName}</span>${thread.unread_count > 0 ? `<span class="badge">${thread.unread_count}</span>` : ''}</span><span class="tag-buttons">${createTagButtons(meta)}</span></p>
-                            <small class="advert-title">${shortTitle}</small>
-                            <small class="last-date">Последно: ${lastDate}</small>
-                        </div>
-                    `;
+                    for (const { thread, meta, lastDateRaw, isRead, lastDate } of processed) {
+                        const within48 = now - new Date(lastDateRaw).getTime() <= 48 * 60 * 60 * 1000;
+                        if (option === 'unsent') {
+                            if (!(within48 && !meta.checked && (meta.redMark || meta.blueMark))) continue;
+                        } else if (option === 'noanswer') {
+                            if (!(within48 && !meta.checked && meta.lastSenderType === 'received')) continue;
+                        }
 
-                    const info = threadElement.querySelector('.thread-item-info');
-                    const tagContainer = threadElement.querySelector('.tag-buttons');
-                    attachTagButtonEvents(tagContainer, meta, thread.id);
-                    info.addEventListener('click', () => {
-                        document.querySelectorAll('.thread-item').forEach(el => el.classList.remove('active'));
-                        threadElement.classList.add('active');
-                        displayMessages(thread.id);
-                        showThreadOnMobile();
-                    });
+                        const conversationId = thread.id;
+                        const advertTitle = meta.advertTitle || '';
+                        const displayName = meta.contactName || getFirstWords(meta.deliveryInfo?.name, 2) || thread.contact_name || conversationId;
+                        if (!meta.contactName && meta.deliveryInfo?.name) {
+                            meta.contactName = getFirstWords(meta.deliveryInfo.name, 2);
+                            saveThreadMeta(thread.id, meta);
+                        }
+                        const shortTitle = getFirstWords(advertTitle, 2);
 
-                    refreshThreadDetails(thread.id, threadElement, meta);
+                        const threadElement = document.createElement('div');
+                        threadElement.className = 'thread-item';
+                        threadElement.dataset.threadId = thread.id;
+                        if (!isRead) threadElement.classList.add('unread');
 
-                    elements.threadsList.appendChild(threadElement);
-                }
+                        threadElement.innerHTML = `
+                            <input type="checkbox" class="thread-checkbox" data-id="${thread.id}" name="thread-checkbox-${thread.id}">
+                            <div class="thread-item-info">
+                                <p><span class="conversation-id-wrapper"><span class="conversation-id">${displayName}</span>${thread.unread_count > 0 ? `<span class="badge">${thread.unread_count}</span>` : ''}</span><span class="tag-buttons">${createTagButtons(meta)}</span></p>
+                                <small class="advert-title">${shortTitle}</small>
+                                <small class="last-date">Последно: ${lastDate}</small>
+                            </div>
+                        `;
+
+                        const info = threadElement.querySelector('.thread-item-info');
+                        const tagContainer = threadElement.querySelector('.tag-buttons');
+                        attachTagButtonEvents(tagContainer, meta, thread.id);
+                        info.addEventListener('click', () => {
+                            document.querySelectorAll('.thread-item').forEach(el => el.classList.remove('active'));
+                            threadElement.classList.add('active');
+                            displayMessages(thread.id);
+                            showThreadOnMobile();
+                        });
+
+                        refreshThreadDetails(thread.id, threadElement, meta);
+
+                        elements.threadsList.appendChild(threadElement);
+                    }
             } catch (error) {
                 elements.threadsList.innerHTML = `<p style="color: red; padding: 15px;">${error.message}</p>`;
             } finally {


### PR DESCRIPTION
## Обобщение
- добавен е `try` блок около основната логика на `fetchThreads`
- запазени са съществуващите `catch` и `finally` блокове

## Тестване
- `npm test` *(липсва `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae185b38cc83268a1154c449b7735c