### PR TITLE
Байпас на кеша на Worker-а при обновяване на разговори и съобщения

### DIFF
--- a/index.html
+++ b/index.html
@@ -429,7 +429,8 @@
 
                 if (!threads) {
                     try {
-                        const response = await authorizedFetch(`${API_BASE_URL}/api/threads`);
+                        const url = `${API_BASE_URL}/api/threads${force ? '?forceRefresh=1' : ''}`;
+                        const response = await authorizedFetch(url);
                         if (!response.ok) {
                             const errorData = await response.json();
                             throw new Error(`${errorData.error} <a href="${AUTH_URL}">Оторизирайте се отново</a>.`);
@@ -543,7 +544,7 @@
                             showThreadOnMobile();
                         });
 
-                        refreshThreadDetails(thread.id, threadElement, meta);
+                        refreshThreadDetails(thread.id, threadElement, meta, force);
 
                         elements.threadsList.appendChild(threadElement);
                     }
@@ -554,10 +555,11 @@
             }
         }
 
-        async function refreshThreadDetails(id, threadElement, meta) {
+        async function refreshThreadDetails(id, threadElement, meta, force = false) {
             const advertEl = threadElement.querySelector('.advert-title');
             try {
-                const response = await authorizedFetch(`${API_BASE_URL}/api/threads/${id}/details`);
+                const url = `${API_BASE_URL}/api/threads/${id}/details${force ? '?forceRefresh=1' : ''}`;
+                const response = await authorizedFetch(url);
                 if (!response.ok) throw new Error('fetch failed');
                 const data = await response.json();
                 meta.advertTitle = data.advertTitle || '';
@@ -601,7 +603,7 @@
             if (nameEl) nameEl.textContent = meta.contactName || id;
         }
 
-        async function displayMessages(threadId) {
+        async function displayMessages(threadId, force = false) {
             currentThreadId = threadId;
             showView(elements.chatView);
             renderChatTags(threadId);
@@ -610,12 +612,16 @@
             elements.analyzerInput.value = '';
 
             let messages = null;
-            const cached = loadMessagesFromCache(threadId);
-            if (cached && Date.now() - cached.timestamp < MESSAGES_TTL) {
-                messages = cached.data;
-            } else {
+            if (!force) {
+                const cached = loadMessagesFromCache(threadId);
+                if (cached && Date.now() - cached.timestamp < MESSAGES_TTL) {
+                    messages = cached.data;
+                }
+            }
+            if (!messages) {
                 try {
-                    const response = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/messages`);
+                    const url = `${API_BASE_URL}/api/threads/${threadId}/messages${force ? '?forceRefresh=1' : ''}`;
+                    const response = await authorizedFetch(url);
                     if (!response.ok) throw new Error('Неуспешно зареждане на съобщенията.');
                     messages = await response.json();
                     saveMessagesToCache(threadId, messages);
@@ -720,7 +726,7 @@
                 localStorage.removeItem(`thread_messages_${currentThreadId}`);
                 elements.replyText.value = '';
                 autoResizeReplyText();
-                setTimeout(() => displayMessages(currentThreadId), 1000);
+                setTimeout(() => displayMessages(currentThreadId, true), 1000);
             } catch (error) {
                 alert(`Грешка при изпращане: ${error.message}`);
             } finally {
@@ -861,7 +867,7 @@
                     body: JSON.stringify({ text })
                 });
                 if (currentThreadId === threadId) {
-                    setTimeout(() => displayMessages(threadId), 1000);
+                    setTimeout(() => displayMessages(threadId, true), 1000);
                 }
             } catch (err) {
                 console.warn('Неуспешно изпращане на автоматично съобщение', err);


### PR DESCRIPTION
## Summary
- добавен параметър `forceRefresh=1` при зареждане на нишки, детайли и съобщения
- принудително опресняване на интерфейса след изпращане на съобщение

## Testing
- `npm test` (липсва `package.json`)


------
https://chatgpt.com/codex/tasks/task_e_68ae1b27dd488326af7ea0e2ebaec842