### PR TITLE
Почистване на изтекъл кеш при зареждане и опресняване

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,6 +311,7 @@
 
         // --- EVENT LISTENERS ---
         document.addEventListener('DOMContentLoaded', () => {
+            cleanupExpiredCache();
             fetchThreads();
 
             if (isMobile()) {
@@ -318,6 +319,7 @@
             }
 
             elements.refreshButton.addEventListener('click', () => {
+                cleanupExpiredCache();
                 clearCache();
                 fetchThreads(true);
             });
@@ -1103,6 +1105,23 @@
             localStorage.removeItem(THREADS_CACHE_KEY);
             Object.keys(localStorage).forEach(k => {
                 if (k.startsWith('thread_messages_')) localStorage.removeItem(k);
+            });
+        }
+
+        function cleanupExpiredCache() {
+            Object.keys(localStorage).forEach(key => {
+                let ttl = null;
+                if (key === THREADS_CACHE_KEY) ttl = THREADS_TTL;
+                else if (key.startsWith('thread_messages_')) ttl = MESSAGES_TTL;
+                if (!ttl) return;
+                try {
+                    const item = JSON.parse(localStorage.getItem(key));
+                    if (item && item.timestamp && item.timestamp + ttl < Date.now()) {
+                        localStorage.removeItem(key);
+                    }
+                } catch {
+                    // ignore
+                }
             });
         }
 


### PR DESCRIPTION
## Резюме
- добавена е функция `cleanupExpiredCache` за изчистване на изтекли записи в localStorage
- извикване на почистването при `DOMContentLoaded` и натискане на бутона за опресняване

## Тестване
- `npm test` *(липсва `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1b50b8d08326b173e9244da7cf5d