### PR TITLE
Handle fetch errors and remove keepalive option

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -10,7 +10,11 @@
     const token = getToken();
     if (token) headers.set('Authorization', `Bearer ${token}`);
     options.headers = headers;
-    return fetch(url, options);
+    try {
+      return await fetch(url, options);
+    } catch (err) {
+      throw new Error('Няма връзка с API-то');
+    }
   }
   window.authorizedFetch = authorizedFetch;
 })();

--- a/index.html
+++ b/index.html
@@ -684,13 +684,15 @@
 
         async function markThreadRead(threadId) {
             try {
-                const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, { method: 'POST', keepalive: true });
+                const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, { method: 'POST' });
                 if (!resp.ok) {
                     console.warn('Неуспешно маркиране на прочетено', resp.status, resp.statusText);
+                    alert('Неуспешно маркиране на прочетено');
                     return;
                 }
             } catch (err) {
                 console.warn('Неуспешно маркиране на прочетено', err);
+                alert(err.message || 'Неуспешно маркиране на прочетено');
                 return;
             }
 


### PR DESCRIPTION
## Summary
- remove `keepalive` option when marking threads as read
- surface alert on failed "mark read" attempts
- wrap authorized fetch with error handling for missing API connection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1e18d42c8326a50319a7548eaf1a