### PR TITLE
Добавяне на JSON headers при markThreadRead

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,7 +643,12 @@
 
         async function markThreadRead(threadId) {
             try {
-                const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, { method: 'POST', keepalive: true });
+                const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, {
+                    method: 'POST',
+                    keepalive: true,
+                    headers: { 'Content-Type': 'application/json' },
+                    body: '{}'
+                });
                 if (!resp.ok) {
                     console.warn('Неуспешно маркиране на прочетено', resp.status, resp.statusText);
                     return;


### PR DESCRIPTION
## Summary
- добавен Content-Type и празно JSON тяло към `markThreadRead`, за да е съвместимо с API

## Testing
- `npm test` *(очаквано грешка: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae640881fc83269e1047e2309a2e13