### PR TITLE
refactor: drop keepalive for thread read

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,12 +643,11 @@
 
         async function markThreadRead(threadId) {
             try {
-                const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, {
-                    method: 'POST',
-                    keepalive: true,
-                    headers: { 'Content-Type': 'application/json' },
-                    body: '{}'
-                });
+        const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}'
+        });
                 if (!resp.ok) {
                     console.warn('Неуспешно маркиране на прочетено', resp.status, resp.statusText);
                     return;


### PR DESCRIPTION
## Summary
- remove unnecessary `keepalive: true` option in thread read marking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae65c728048326bbaa6448000466c6