### PR TITLE
feat: send empty JSON when marking thread read

### DIFF
--- a/index.html
+++ b/index.html
@@ -645,7 +645,6 @@
             try {
                 const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, {
                     method: 'POST',
-                    keepalive: true,
                     headers: { 'Content-Type': 'application/json' },
                     body: '{}'
                 });


### PR DESCRIPTION
## Summary
- remove `keepalive` from `markThreadRead`
- send empty JSON body with `Content-Type` header when marking threads read

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae665041708326a4258f91460fc972