### PR TITLE
Добавен try/catch в authorizedFetch за мрежови грешки

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -10,7 +10,12 @@
     const token = getToken();
     if (token) headers.set('Authorization', `Bearer ${token}`);
     options.headers = headers;
-    return fetch(url, options);
+    try {
+      return await fetch(url, options);
+    } catch (err) {
+      console.error('Network error:', err);
+      throw err;
+    }
   }
   window.authorizedFetch = authorizedFetch;
 })();


### PR DESCRIPTION
## Обобщение
- обгърнат fetch с try/catch в `authorizedFetch`
- при неуспех логва `console.error('Network error:', err)` и хвърля грешката

## Тестване
- `npm test` (грешка: липсва package.json)


------
https://chatgpt.com/codex/tasks/task_e_68ae66540ff883269cbac110f72156e0