### PR TITLE
Добавена обработка на мрежови грешки

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -6,11 +6,19 @@
   }
 
   async function authorizedFetch(url, options = {}) {
-    const headers = new Headers(options.headers || {});
+    const { throwOnError, ...fetchOptions } = options;
+    const headers = new Headers(fetchOptions.headers || {});
     const token = getToken();
     if (token) headers.set('Authorization', `Bearer ${token}`);
-    options.headers = headers;
-    return fetch(url, options);
+    fetchOptions.headers = headers;
+    try {
+      return await fetch(url, fetchOptions);
+    } catch (err) {
+      if (throwOnError) {
+        throw new Error(`Network error: ${err.message}`);
+      }
+      return { ok: false, error: err.message };
+    }
   }
   window.authorizedFetch = authorizedFetch;
 })();

--- a/index.html
+++ b/index.html
@@ -568,6 +568,8 @@
                             meta.contactName = getFirstWords(fullName, 2);
                             saveThreadMeta(id, meta);
                         }
+                    } else {
+                        alert(`Грешка при анализ на нишката: ${resp.error || resp.statusText || 'Неизвестна грешка'}`);
                     }
                 } catch (e) { }
             }
@@ -650,11 +652,11 @@
                     body: '{}'
                 });
                 if (!resp.ok) {
-                    console.warn('Неуспешно маркиране на прочетено', resp.status, resp.statusText);
+                    alert(`Неуспешно маркиране на прочетено: ${resp.error || resp.statusText || 'Неизвестна грешка'}`);
                     return;
                 }
             } catch (err) {
-                console.warn('Неуспешно маркиране на прочетено', err);
+                alert(`Неуспешно маркиране на прочетено: ${err.message}`);
                 return;
             }
 


### PR DESCRIPTION
## Резюме
- обвит `fetch` в `authorizedFetch` с `try/catch`, избор за хвърляне или връщане на грешка
- показване на понятни съобщения при грешки в `index.html`

## Тестване
- `node --check auth.js`
- `npm test` *(очаквано: липсва `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae65c05b048326a8d42e0c69f81010