### PR TITLE
Improve error handling in authorizedFetch

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -10,7 +10,21 @@
     const token = getToken();
     if (token) headers.set('Authorization', `Bearer ${token}`);
     options.headers = headers;
-    return fetch(url, options);
+
+    try {
+      const resp = await fetch(url, options);
+      if (!resp.ok) {
+        let msg = resp.statusText;
+        try {
+          const errData = await resp.json();
+          msg = errData?.error || errData?.message || msg;
+        } catch (_) {}
+        throw new Error(msg);
+      }
+      return resp;
+    } catch (err) {
+      throw new Error('Network error: ' + err.message);
+    }
   }
   window.authorizedFetch = authorizedFetch;
 })();


### PR DESCRIPTION
## Summary
- wrap fetch calls in try/catch and rethrow network errors
- check `resp.ok` and surface server error messages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6f5088dc832689472fe102e79673