### PR TITLE
fix: send JSON payload when marking thread as read

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,7 +643,11 @@
 
         async function markThreadRead(threadId) {
             try {
-                const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, { method: 'POST', keepalive: true });
+                const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: '{}'
+                });
                 if (!resp.ok) {
                     console.warn('Неуспешно маркиране на прочетено', resp.status, resp.statusText);
                     return;


### PR DESCRIPTION
## Summary
- avoid `TypeError: Failed to fetch` by sending explicit JSON body when marking threads as read

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68afacc8169c8326b6fa1cc55affa9de