### PR TITLE
Актуализиране на пътя mark_as_read

### DIFF
--- a/index.html
+++ b/index.html
@@ -643,7 +643,7 @@
 
         async function markThreadRead(threadId) {
             try {
-                const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark-read`, {
+                const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/mark_as_read`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: '{}'

--- a/worker.js
+++ b/worker.js
@@ -44,7 +44,7 @@ export default {
       const sendMatch = path.match(/^\/api\/threads\/(\d+)\/send-message$/);
       if (sendMatch && method === 'POST') return this.sendMessage(request, env, sendMatch[1]);
 
-      const markReadMatch = path.match(/^\/api\/threads\/(\d+)\/mark-read$/);
+      const markReadMatch = path.match(/^\/api\/threads\/(\d+)\/mark_as_read$/);
       if (markReadMatch && method === 'POST') return this.markThreadRead(request, env, markReadMatch[1]);
 
       const advertMatch = path.match(/^\/api\/adverts\/(\d+)$/);
@@ -242,7 +242,7 @@ export default {
       const accessToken = await getValidAccessToken(env);
       if (!accessToken) return jsonResponse({ error: "Authentication required." }, 401);
 
-      const response = await fetch(`https://www.olx.bg/api/partner/threads/${threadId}/mark-read`, {
+      const response = await fetch(`https://www.olx.bg/api/partner/threads/${threadId}/mark_as_read`, {
           method: 'POST',
           headers: { 'Authorization': `Bearer ${accessToken}`, 'Version': '2.0' }
       });


### PR DESCRIPTION
## Обобщение
- Променен е фронтенд заявката към `/mark_as_read` при маркиране на разговор
- Актуализиран е рутерът и вътрешният fetch в Worker-а към новия OLX API път
- Функцията `markThreadRead` връща `jsonResponse({ success: true })`

## Тестване
- `npm test` *(липсва package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afb12274bc83268671a4faaecdb8cd