### PR TITLE
Allow alphanumeric thread IDs for mark_as_read

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -44,7 +44,7 @@ export default {
       const sendMatch = path.match(/^\/api\/threads\/(\d+)\/send-message$/);
       if (sendMatch && method === 'POST') return this.sendMessage(request, env, sendMatch[1]);
 
-      const markReadMatch = path.match(/^\/api\/threads\/(\d+)\/mark_as_read$/);
+      const markReadMatch = path.match(/^\/api\/threads\/([\w-]+)\/mark_as_read$/);
       if (markReadMatch && method === 'POST') return this.markThreadRead(request, env, markReadMatch[1]);
 
       const advertMatch = path.match(/^\/api\/adverts\/(\d+)$/);


### PR DESCRIPTION
## Summary
- allow letters and hyphens in `/api/threads/:id/mark_as_read`

## Testing
- `node --check worker.js`
- (attempted) `npx wrangler deploy worker.js --name olx`

------
https://chatgpt.com/codex/tasks/task_e_68afbcfe328483268867aa58c8a6a039