### PR TITLE
refactor: handle authorized fetch errors in UI

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -12,18 +12,9 @@
     options.headers = headers;
 
     try {
-      const resp = await fetch(url, options);
-      if (!resp.ok) {
-        let msg = resp.statusText;
-        try {
-          const errData = await resp.json();
-          msg = errData?.error || errData?.message || msg;
-        } catch (_) {}
-        throw new Error(msg);
-      }
-      return resp;
+      return await fetch(url, options);
     } catch (err) {
-      throw new Error('Network error: ' + err.message);
+      throw err;
     }
   }
   window.authorizedFetch = authorizedFetch;

--- a/index.html
+++ b/index.html
@@ -733,13 +733,17 @@
                 });
                 const genData = await genRes.json();
                 if (!genRes.ok) throw new Error(genData.error);
-                await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/send-message`, {
+                const sendRes = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/send-message`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ text: genData.reply })
                 });
+                if (!sendRes.ok) {
+                    const sendData = await sendRes.json().catch(() => ({}));
+                    throw new Error(sendData.error || sendRes.statusText);
+                }
             } catch (err) {
-                console.error('Автоматичният отговор се провали:', err);
+                alert(`Автоматичният отговор се провали: ${err.message}`);
             }
         }
 
@@ -825,16 +829,21 @@
         async function sendAutoMessage(threadId, text) {
             try {
                 markThreadRead(threadId);
-                await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/send-message`, {
+                const resp = await authorizedFetch(`${API_BASE_URL}/api/threads/${threadId}/send-message`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ text })
                 });
+                if (!resp.ok) {
+                    const errData = await resp.json().catch(() => ({}));
+                    alert(`Автоматичното съобщение не бе изпратено: ${errData.error || resp.statusText}`);
+                    return;
+                }
                 if (currentThreadId === threadId) {
                     setTimeout(() => displayMessages(threadId), 1000);
                 }
             } catch (err) {
-                console.warn('Неуспешно изпращане на автоматично съобщение', err);
+                alert(`Автоматичното съобщение не бе изпратено: ${err.message}`);
             }
         }
 


### PR DESCRIPTION
## Summary
- simplify `authorizedFetch` to return raw fetch errors
- show API error status and messages in auto reply helpers

## Testing
- `node --check auth.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afbcfaae1c8326821eb4659536ffc0